### PR TITLE
fix: Closing bracket is missing in Form With Validation step 3

### DIFF
--- a/docs/form.md
+++ b/docs/form.md
@@ -125,7 +125,7 @@ export default function () {
 
 Create a button to validate and submit the form.
 
-```SnackPlayer name=Form%20Example(Validate and Submit)
+```SnackPlayer name=Form%20Example(Validate%20and%20Submit)
 import React from 'react';
 import {
   VStack,


### PR DESCRIPTION
In SnackPlayer, if we put a space, it interprets it as the end. We need to use code `%20` to show a space