### PR TITLE
Update Accordion.md, fixing component names

### DIFF
--- a/versioned_docs/version-3.2.1/migration/Accordion.md
+++ b/versioned_docs/version-3.2.1/migration/Accordion.md
@@ -60,25 +60,25 @@ export default function () {
   return (
     <Accordion index={[0]}>
       <Accordion.Item>
-        <Accordion.Button>
+        <Accordion.Summary>
           First Element
           <Accordion.Icon />
-        </Accordion.Button>
-        <Accordion.Panel>Lorem ipsum dolor sit amet</Accordion.Panel>
+        </Accordion.Summary>
+        <Accordion.Details>Lorem ipsum dolor sit amet</Accordion.Details>
       </Accordion.Item>
       <Accordion.Item>
-        <Accordion.Button>
+        <Accordion.Summary>
           Second Element
           <Accordion.Icon />
-        </Accordion.Button>
-        <Accordion.Panel>Lorem ipsum dolor sit amet</Accordion.Panel>
+        </Accordion.Summary>
+        <Accordion.Details>Lorem ipsum dolor sit amet</Accordion.Details>
       </Accordion.Item>
       <Accordion.Item>
-        <Accordion.Button>
+        <Accordion.Summary>
           Third Element
           <Accordion.Icon />
-        </Accordion.Button>
-        <Accordion.Panel>Lorem ipsum dolor sit amet</Accordion.Panel>
+        </Accordion.Summary>
+        <Accordion.Details>Lorem ipsum dolor sit amet</Accordion.Details>
       </Accordion.Item>
     </Accordion>
   );


### PR DESCRIPTION
The components Accordion.Button and Accordion.Panel doesn't seem to exist and that can be misleading. I found out that the current respective names of those components are: Accordion.Summary and Accordion.Details (just like the HTML tag names). Because of this discovery I replaced the names that were in the documentation.