### PR TITLE
Fix NextJs installation steps add icon support

### DIFF
--- a/docs/install-next.mdx
+++ b/docs/install-next.mdx
@@ -134,7 +134,7 @@ We'll need 2 more additional steps.
   <TabItem value="yarn">
 
 ```bash
-  yarn add next-compose-plugins next-transpile-modules -D
+  yarn add next-compose-plugins next-transpile-modules @expo/next-adapter -D
 ```
 
   </TabItem>
@@ -152,6 +152,7 @@ We'll need 2 more additional steps.
 2. Update your next.config.js with the below content.
 
 ```js
+const { withExpo } = require('@expo/next-adapter');
 const withPlugins = require('next-compose-plugins');
 const withTM = require('next-transpile-modules')([
   'native-base',
@@ -176,6 +177,7 @@ const withTM = require('next-transpile-modules')([
 module.exports = withPlugins(
   [
     withTM,
+    [withExpo, { projectRoot: __dirname }],
     // your plugins go here.
   ],
   {


### PR DESCRIPTION
This PR adds icon support in nextjs installation steps.