### PR TITLE
Add VSCode extension link in the docs

### DIFF
--- a/docs/3.3.x/installation.mdx
+++ b/docs/3.3.x/installation.mdx
@@ -19,7 +19,7 @@ Refer the guides shown below to setup NativeBase in your React app.
 
 ### NativeBase VS Code Extensions
 
-NativeBase VS Code Extensions are specifically designed to quicken your development process using **NativeBase 3.0**.
+[NativeBase VS Code Extensions](https://marketplace.visualstudio.com/items?itemName=NativeBase.nativebase-v3-vscode-extension) are specifically designed to quicken your development process using **NativeBase 3.0**.
 NativeBase snippets are shorthand for commonly used NativeBase components.
 
 All snippets start with the prefix `nb-` and are followed by the name of the desired component.

--- a/docs/next/installation.mdx
+++ b/docs/next/installation.mdx
@@ -19,7 +19,7 @@ Refer the guides shown below to setup NativeBase in your React app.
 
 ### NativeBase VS Code Extensions
 
-NativeBase VS Code Extensions are specifically designed to quicken your development process using **NativeBase 3.0**.
+[NativeBase VS Code Extensions](https://marketplace.visualstudio.com/items?itemName=NativeBase.nativebase-v3-vscode-extension) are specifically designed to quicken your development process using **NativeBase 3.0**.
 NativeBase snippets are shorthand for commonly used NativeBase components.
 
 All snippets start with the prefix `nb-` and are followed by the name of the desired component.


### PR DESCRIPTION
This PR adds the [VSCode extension link](https://marketplace.visualstudio.com/items?itemName=NativeBase.nativebase-v3-vscode-extension) for NativeBase to the current and next version of the docs.