### PR TITLE
Updated Content Changes in setup-provider

### DIFF
--- a/docs/3.0.x/setup-provider.md
+++ b/docs/3.0.x/setup-provider.md
@@ -56,7 +56,7 @@ function App() {
 
 If you want to do something with the color modes in your app, you can use colorModeManager Prop of NativeBaseProvider to achieve it.
 
-In the below example we will show how to store the active ColorMode in an async storage, so it can be consistent all around your app.
+In the example below, we show how to store the active ColorMode in an async storage, so it can be consistent all around your app.
 
 ```tsx
 import React from 'react';
@@ -93,7 +93,7 @@ export default ({ children, theme }: any) => {
 
 ## Add external dependencies (Optional)
 
-If you want to use [Gradient feature in Box](box#with-linear-gradient), you need to pass linear gradient dependency as a config object in NativeBaseProvider. This dependency can be either from [expo-linear-gradient](https://docs.expo.io/versions/latest/sdk/linear-gradient/) or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient)
+If you want to use the [Gradient feature in Box](box#with-linear-gradient),it has to pass linear gradient dependency as a config object in NativeBaseProvider. This dependency can be either from [expo-linear-gradient](https://docs.expo.io/versions/latest/sdk/linear-gradient/) or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient).
 
 ```jsx
 import React from 'react';
@@ -124,6 +124,6 @@ export default () => {
 | Name                 | Type                                | Description                                                                                                                                | Default                  |
 | -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
 | initialWindowMetrics | Object                              | Mock data for frame and insets. [Refer this](https://github.com/th3rdwave/react-native-safe-area-context#testing) for further information. | -                        |
-| colorModeManager     | { get : Function , set : Function } | Manage Color mode in your app                                                                                                              | -                        |
-| theme                | Object                              | use custom theme in your app                                                                                                               | NativeBase Default Theme |
+| colorModeManager     | { get : Function , set : Function } | Manages Color mode in your app                                                                                                              | -                        |
+| theme                | Object                              | Provides a custom theme for your app.                                                                                                               | NativeBase Default Theme |
 | config               | {dependencies: {}}                  | To include external dependencies. For example - [Linear gradient](box#with-linear-gradient)                                                | -                        |

--- a/docs/3.1.x/setup-provider.md
+++ b/docs/3.1.x/setup-provider.md
@@ -56,7 +56,7 @@ function App() {
 
 If you want to do something with the color modes in your app, you can use colorModeManager Prop of NativeBaseProvider to achieve it.
 
-In the below example we will show how to store the active ColorMode in an async storage, so it can be consistent all around your app.
+In the example below, we show how to store the active ColorMode in an async storage, so it can be consistent all around your app.
 
 ```tsx
 import React from 'react';
@@ -93,7 +93,7 @@ export default ({ children, theme }: any) => {
 
 ## Add external dependencies (Optional)
 
-If you want to use [Gradient feature in Box](box#with-linear-gradient), you need to pass linear gradient dependency as a config object in NativeBaseProvider. This dependency can be either from [expo-linear-gradient](https://docs.expo.io/versions/latest/sdk/linear-gradient/) or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient)
+If you want to use the [Gradient feature in Box](box#with-linear-gradient),it has to pass linear gradient dependency as a config object in NativeBaseProvider. This dependency can be either from [expo-linear-gradient](https://docs.expo.io/versions/latest/sdk/linear-gradient/) or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient).
 
 ```jsx
 import React from 'react';
@@ -124,6 +124,6 @@ export default () => {
 | Name                 | Type                                | Description                                                                                                                                | Default                  |
 | -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
 | initialWindowMetrics | Object                              | Mock data for frame and insets. [Refer this](https://github.com/th3rdwave/react-native-safe-area-context#testing) for further information. | -                        |
-| colorModeManager     | { get : Function , set : Function } | Manage Color mode in your app                                                                                                              | -                        |
-| theme                | Object                              | use custom theme in your app                                                                                                               | NativeBase Default Theme |
+| colorModeManager     | { get : Function , set : Function } | Manages Color mode in your app                                                                                                              | -                        |
+| theme                | Object                              | Provides a custom theme for your app.                                                                                                              | NativeBase Default Theme |
 | config               | {dependencies: {}}                  | To include external dependencies. For example - [Linear gradient](box#with-linear-gradient)                                                | -                        |

--- a/docs/3.2.x/setup-provider.md
+++ b/docs/3.2.x/setup-provider.md
@@ -56,7 +56,7 @@ function App() {
 
 If you want to do something with the color modes in your app, you can use colorModeManager Prop of NativeBaseProvider to achieve it.
 
-In the below example we will show how to store the active ColorMode in an async storage, so it can be consistent all around your app.
+In the example below, we show how to store the active ColorMode in an async storage, so it can be consistent all around your app.
 
 ```tsx
 import React from 'react';
@@ -93,7 +93,7 @@ export default ({ children, theme }: any) => {
 
 ## Add external dependencies (Optional)
 
-If you want to use [Gradient feature in Box](box#with-linear-gradient), you need to pass linear gradient dependency as a config object in NativeBaseProvider. This dependency can be either from [expo-linear-gradient](https://docs.expo.io/versions/latest/sdk/linear-gradient/) or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient)
+If you want to use the [Gradient feature in Box](box#with-linear-gradient),it has to pass linear gradient dependency as a config object in NativeBaseProvider. This dependency can be either from [expo-linear-gradient](https://docs.expo.io/versions/latest/sdk/linear-gradient/) or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient).
 
 ```jsx
 import React from 'react';
@@ -124,6 +124,6 @@ export default () => {
 | Name                 | Type                                | Description                                                                                                                                | Default                  |
 | -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
 | initialWindowMetrics | Object                              | Mock data for frame and insets. [Refer this](https://github.com/th3rdwave/react-native-safe-area-context#testing) for further information. | -                        |
-| colorModeManager     | { get : Function , set : Function } | Manage Color mode in your app                                                                                                              | -                        |
-| theme                | Object                              | use custom theme in your app                                                                                                               | NativeBase Default Theme |
+| colorModeManager     | { get : Function , set : Function } | Manages Color mode in your app                                                                                                              | -                        |
+| theme                | Object                              | Provides a custom theme for your app.                                                                                                               | NativeBase Default Theme |
 | config               | {dependencies: {}}                  | To include external dependencies. For example - [Linear gradient](box#with-linear-gradient)                                                | -                        |

--- a/docs/3.3.x/setup-provider.md
+++ b/docs/3.3.x/setup-provider.md
@@ -56,7 +56,7 @@ function App() {
 
 If you want to do something with the color modes in your app, you can use `colorModeManager` Prop of `NativeBaseProvider` to achieve it.
 
-In the below example we will show how to store the active `ColorMode` in an async storage, so it can be consistent all around our app.
+In the example below, we show how to store the active `ColorMode` in an async storage, so it can be consistent all around our app.
 
 ```tsx
 import React from 'react';
@@ -93,8 +93,7 @@ export default ({ children, theme }: any) => {
 
 ## Add external dependencies (Optional)
 
-If you want to use [Gradient feature in Box](box#with-linear-gradient), you need to pass linear gradient dependency as a config object in `NativeBaseProvider`. This dependency can be either from [expo-linear-gradient](https://docs.expo.io/versions/latest/sdk/linear-gradient/) or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient)
-
+If you want to use the [Gradient feature in Box](box#with-linear-gradient),it has to pass linear gradient dependency as a config object in NativeBaseProvider. This dependency can be either from [expo-linear-gradient](https://docs.expo.io/versions/latest/sdk/linear-gradient/) or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient).
 ```jsx
 import React from 'react';
 import { NativeBaseProvider } from 'native-base';
@@ -124,6 +123,6 @@ export default () => {
 | Name                 | Type                                | Description                                                                                                                                | Default                  |
 | -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
 | initialWindowMetrics | Object                              | Mock data for frame and insets. [Refer this](https://github.com/th3rdwave/react-native-safe-area-context#testing) for further information. | -                        |
-| colorModeManager     | { get : Function , set : Function } | Manage Color mode in your app                                                                                                              | -                        |
-| theme                | Object                              | use custom theme in your app                                                                                                               | NativeBase Default Theme |
+| colorModeManager     | { get : Function , set : Function } | Manages Color mode in your app                                                                                                              | -                        |
+| theme                | Object                              | Provides a custom theme for your app.                                                                                                               | NativeBase Default Theme |
 | config               | {dependencies: {}}                  | To include external dependencies. For example - [Linear gradient](box#with-linear-gradient)                                                | -                        |

--- a/docs/3.4.x/setup-provider.md
+++ b/docs/3.4.x/setup-provider.md
@@ -56,7 +56,7 @@ function App() {
 
 If you want to do something with the color modes in your app, you can use colorModeManager Prop of NativeBaseProvider to achieve it.
 
-In the below example we will show how to store the active ColorMode in an async storage, so it can be consistent all around your app.
+In the example below, we show how to store the active ColorMode in an async storage, so it can be consistent all around your app.
 
 ```tsx
 import React from "react";
@@ -93,7 +93,7 @@ export default ({ children, theme }: any) => {
 
 ## Add external dependencies (Optional)
 
-If you want to use [Gradient feature in Box](box#with-linear-gradient), you need to pass linear gradient dependency as a config object in NativeBaseProvider. This dependency can be either from [expo-linear-gradient](https://docs.expo.io/versions/latest/sdk/linear-gradient/) or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient)
+If you want to use the [Gradient feature in Box](box#with-linear-gradient),it has to pass linear gradient dependency as a config object in NativeBaseProvider. This dependency can be either from [expo-linear-gradient](https://docs.expo.io/versions/latest/sdk/linear-gradient/) or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient).
 
 ```jsx
 import React from "react";
@@ -142,8 +142,8 @@ export default () => {
 
 | Name                 | Type                                | Description                                                                                                                                | Default                  |
 | -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
-| isSSR                | Boolean                             | Tells the provider if your app is Server Side Rendered or not?                                                                             | -                        |
+| isSSR                | Boolean                             | Tells the provider if your app is rendered on the server side or not.                                                                            | -                        |
 | initialWindowMetrics | Object                              | Mock data for frame and insets. [Refer this](https://github.com/th3rdwave/react-native-safe-area-context#testing) for further information. | -                        |
-| colorModeManager     | { get : Function , set : Function } | Manage Color mode in your app                                                                                                              | -                        |
-| theme                | Object                              | use custom theme in your app                                                                                                               | NativeBase Default Theme |
+| colorModeManager     | { get : Function , set : Function } | Manages Color mode in your app                                                                                                              | -                        |
+| theme                | Object                              | Provides a custom theme for your app.                                                                                                               | NativeBase Default Theme |
 | config               | {dependencies: {}}                  | To include external dependencies. For example - [Linear gradient](box#with-linear-gradient)                                                | -                        |

--- a/docs/next/setup-provider.md
+++ b/docs/next/setup-provider.md
@@ -56,7 +56,7 @@ function App() {
 
 If you want to do something with the color modes in your app, you can use colorModeManager Prop of NativeBaseProvider to achieve it.
 
-In the below example we will show how to store the active ColorMode in an async storage, so it can be consistent all around your app.
+In the example below, we show how to store the active ColorMode in an async storage, so it can be consistent all around your app.
 
 ```tsx
 import React from "react";
@@ -93,7 +93,7 @@ export default ({ children, theme }: any) => {
 
 ## Add external dependencies (Optional)
 
-If you want to use [Gradient feature in Box](box#with-linear-gradient), you need to pass linear gradient dependency as a config object in NativeBaseProvider. This dependency can be either from [expo-linear-gradient](https://docs.expo.io/versions/latest/sdk/linear-gradient/) or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient)
+If you want to use the [Gradient feature in Box](box#with-linear-gradient),it has to pass linear gradient dependency as a config object in NativeBaseProvider. This dependency can be either from [expo-linear-gradient](https://docs.expo.io/versions/latest/sdk/linear-gradient/) or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient).
 
 ```jsx
 import React from "react";
@@ -142,8 +142,8 @@ export default () => {
 
 | Name                 | Type                                | Description                                                                                                                                | Default                  |
 | -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
-| isSSR                | Boolean                             | Tells the provider if your app is Server Side Rendered or not?                                                                             | -                        |
+| isSSR                | Boolean                             | Tells the provider if your app is rendered on the server side or not.                                                                            | -                        |
 | initialWindowMetrics | Object                              | Mock data for frame and insets. [Refer this](https://github.com/th3rdwave/react-native-safe-area-context#testing) for further information. | -                        |
-| colorModeManager     | { get : Function , set : Function } | Manage Color mode in your app                                                                                                              | -                        |
-| theme                | Object                              | use custom theme in your app                                                                                                               | NativeBase Default Theme |
+| colorModeManager     | { get : Function , set : Function } | Manages Color mode in your app                                                                                                              | -                        |
+| theme                | Object                              | Provides a custom theme for your app.                                                                                                               | NativeBase Default Theme |
 | config               | {dependencies: {}}                  | To include external dependencies. For example - [Linear gradient](box#with-linear-gradient)                                                | -                        |


### PR DESCRIPTION
old Content -
In the below example we will show how
If you want to use Gradient feature in Box, you need to pass linear gradient
react-native-linear-gradient
if your app is Server Side Rendered or not?
Manage Color mode in your app
use custom theme in your app
new content -
In the example below, we show how
If you want to use the Gradient feature in Box, it has to pass the linear gradient
react-native-linear-gradient .
if your app is rendered on the server side or not.
Manages Color mode in your app.
Provides a custom theme for your app.