### PR TITLE
Updated Link in installation

### DIFF
--- a/docs/3.0.x/installation.mdx
+++ b/docs/3.0.x/installation.mdx
@@ -5,7 +5,7 @@ title: Installation
 
 import { InstallationTiles } from "../../src/components";
 
-**NativeBase** is supported in [Expo](https://docs.expo.io/get-started/installation/) or React Native CLI initiated apps. Web support is made possible by [react-native-web](https://necolas.github.io/react-native-web/).
+**NativeBase** is supported in [Expo](https://docs.expo.dev/get-started/installation/) or React Native CLI initiated apps. Web support is made possible by [react-native-web](https://necolas.github.io/react-native-web/).
 
 Refer the guides shown below to setup NativeBase in your React app.
 

--- a/docs/3.1.x/installation.mdx
+++ b/docs/3.1.x/installation.mdx
@@ -5,7 +5,7 @@ title: Installation
 
 import { InstallationTiles } from "../../src/components";
 
-**NativeBase** is supported in [Expo](https://docs.expo.io/get-started/installation/) or React Native CLI initiated apps. Web support is made possible by [react-native-web](https://necolas.github.io/react-native-web/).
+**NativeBase** is supported in [Expo](https://docs.expo.dev/get-started/installation/) or React Native CLI initiated apps. Web support is made possible by [react-native-web](https://necolas.github.io/react-native-web/).
 
 Refer the guides shown below to setup NativeBase in your React app.
 

--- a/docs/3.2.x/installation.mdx
+++ b/docs/3.2.x/installation.mdx
@@ -5,7 +5,7 @@ title: Installation
 
 import { InstallationTiles } from "../../src/components";
 
-**NativeBase** is supported in [Expo](https://docs.expo.io/get-started/installation/) or React Native CLI initiated apps. Web support is made possible by [react-native-web](https://necolas.github.io/react-native-web/).
+**NativeBase** is supported in [Expo](https://docs.expo.dev/get-started/installation/) or React Native CLI initiated apps. Web support is made possible by [react-native-web](https://necolas.github.io/react-native-web/).
 
 Refer the guides shown below to setup NativeBase in your React app.
 

--- a/docs/3.3.x/installation.mdx
+++ b/docs/3.3.x/installation.mdx
@@ -5,7 +5,7 @@ title: Installation
 
 import { InstallationTiles } from "../src/components";
 
-**NativeBase** is supported in [Expo](https://docs.expo.io/get-started/installation/) or React Native CLI initiated apps. Web support is made possible by [react-native-web](https://necolas.github.io/react-native-web/).
+**NativeBase** is supported in [Expo](https://docs.expo.dev/get-started/installation/) or React Native CLI initiated apps. Web support is made possible by [react-native-web](https://necolas.github.io/react-native-web/).
 
 Refer the guides shown below to setup NativeBase in your React app.
 

--- a/docs/3.4.x/installation.mdx
+++ b/docs/3.4.x/installation.mdx
@@ -5,7 +5,7 @@ title: Installation
 
 import { InstallationTiles } from "../src/components";
 
-**NativeBase** is supported in [Expo](https://docs.expo.io/get-started/installation/) or React Native CLI initiated apps. Web support is made possible by [react-native-web](https://necolas.github.io/react-native-web/).
+**NativeBase** is supported in [Expo](https://docs.expo.dev/get-started/installation/) or React Native CLI initiated apps. Web support is made possible by [react-native-web](https://necolas.github.io/react-native-web/).
 
 Refer the guides shown below to setup NativeBase in your React app.
 

--- a/docs/next/installation.mdx
+++ b/docs/next/installation.mdx
@@ -5,7 +5,7 @@ title: Installation
 
 import { InstallationTiles } from "../src/components";
 
-**NativeBase** is supported in [Expo](https://docs.expo.io/get-started/installation/) or React Native CLI initiated apps. Web support is made possible by [react-native-web](https://necolas.github.io/react-native-web/).
+**NativeBase** is supported in [Expo](https://docs.expo.dev/get-started/installation/) or React Native CLI initiated apps. Web support is made possible by [react-native-web](https://necolas.github.io/react-native-web/).
 
 Refer the guides shown below to setup NativeBase in your React app.
 


### PR DESCRIPTION
Anchor Text - Expo
Updated Link - https://docs.expo.dev/get-started/installation/