### PR TITLE
Updated Content Changes in utility-props-specificity

### DIFF
--- a/docs/3.2.x/utility-props-specificity.md
+++ b/docs/3.2.x/utility-props-specificity.md
@@ -9,7 +9,7 @@ title: Utility Props Specificity
   <Input px="2" p="0" />
   ```
 
-  In the above example, we have two similar props for the Input component, but as you might have noticed `px="2"` is more specific than `p="0"` in terms of providing padding to the Input. This follows React Native's specificity precedence while applying utility style props to a component, order does not matter. So, `px="2"` will be applied when the Input component is rendered.
+  In the above example, we have two similar props for the Input component, but as you might have noticed `px="2"` is more specific than `p="0"` in terms of providing padding to the Input. This follows React Native's specificity precedence- while applying utility style props to a component, the order does not matter. So, `px="2"` will be applied when the Input component is rendered.
 
 - If we have a similar prop which is also defined in the baseStyle of that component, the value of the prop will override the value of the prop defined in the baseStyle.
 

--- a/docs/3.3.x/utility-props-specificity.md
+++ b/docs/3.3.x/utility-props-specificity.md
@@ -9,7 +9,7 @@ title: Utility Props Specificity
   <Input px="2" p="0" />
   ```
 
-  In the above example, we have two similar props for the Input component, but as you might have noticed `px="2"` is more specific than `p="0"` in terms of providing padding to the Input. This follows React Native's specificity precedence while applying utility style props to a component, order does not matter. So, `px="2"` will be applied when the Input component is rendered.
+  In the above example, we have two similar props for the Input component, but as you might have noticed `px="2"` is more specific than `p="0"` in terms of providing padding to the Input. This follows React Native's specificity precedence- while applying utility style props to a component, the order does not matter.So, `px="2"` will be applied when the Input component is rendered.
 
 - If we have a similar prop which is also defined in the baseStyle of that component, the value of the prop will override the value of the prop defined in the baseStyle.
 

--- a/docs/3.4.x/utility-props-specificity.md
+++ b/docs/3.4.x/utility-props-specificity.md
@@ -9,7 +9,7 @@ title: Utility Props Specificity
   <Input px="2" p="0" />
   ```
 
-  In the above example, we have two similar props for the Input component, but as you might have noticed `px="2"` is more specific than `p="0"` in terms of providing padding to the Input. This follows React Native's specificity precedence while applying utility style props to a component, order does not matter. So, `px="2"` will be applied when the Input component is rendered.
+  In the above example, we have two similar props for the Input component, but as you might have noticed `px="2"` is more specific than `p="0"` in terms of providing padding to the Input. This follows React Native's specificity precedence- while applying utility style props to a component, the order does not matter.So, `px="2"` will be applied when the Input component is rendered.
 
 - If we have a similar prop which is also defined in the baseStyle of that component, the value of the prop will override the value of the prop defined in the baseStyle.
 

--- a/docs/next/utility-props-specificity.md
+++ b/docs/next/utility-props-specificity.md
@@ -9,7 +9,7 @@ title: Utility Props Specificity
   <Input px="2" p="0" />
   ```
 
-  In the above example, we have two similar props for the Input component, but as you might have noticed `px="2"` is more specific than `p="0"` in terms of providing padding to the Input. This follows React Native's specificity precedence while applying utility style props to a component, order does not matter. So, `px="2"` will be applied when the Input component is rendered.
+  In the above example, we have two similar props for the Input component, but as you might have noticed `px="2"` is more specific than `p="0"` in terms of providing padding to the Input. This follows React Native's specificity precedence- while applying utility style props to a component, the order does not matter.So, `px="2"` will be applied when the Input component is rendered.
 
 - If we have a similar prop which is also defined in the baseStyle of that component, the value of the prop will override the value of the prop defined in the baseStyle
 


### PR DESCRIPTION
Old content - 
React Native's specificity precedence while applying utility style props to a component, order does not matter.
New Content-
React Native's specificity precedence- while applying utility style props to a component, the order does not matter.