### PR TITLE
Updated Content Changes in  safe-area-view-props 

### DIFF
--- a/docs/3.0.x/nativebase-factory.md
+++ b/docs/3.0.x/nativebase-factory.md
@@ -147,5 +147,5 @@ export function Example() {
 
 | Name           | Type            | Description                                                                   | Default |
 | -------------- | --------------- | ----------------------------------------------------------------------------- | ------- |
-| component      | React component | Original component to be passed on which nativebase props have to be applied. | -       |
+| component      | React component | Original component to be passed on which NativeBase props have to be applied. | -       |
 | componentTheme | Object          | This object can include `baseStyle`, `sizes`, `variants`, `defaultProps`      | -       |

--- a/docs/3.0.x/safe-area-view-props.md
+++ b/docs/3.0.x/safe-area-view-props.md
@@ -3,7 +3,7 @@ id: safe-area-view-props
 title: SafeAreaView Props
 ---
 
-To make your components respect the [SafeAreaView](https://reactnative.dev/docs/safeareaview) of the device, we have provided some props that you can use with Box component. They apply a safe padding to your component in the parts decided by the passed props. These props accept either a boolean or a number. If boolean is passed then component takes flexible inset and adjusts its children according to the the device. If a number is passed then it provides a fixed inset in the chosen direction.
+To make your components respect the [SafeAreaView](https://reactnative.dev/docs/safeareaview) of the device, we have provided some props that you can use with Box component. They apply a safe padding to your component in the parts decided by the passed props. These props accept either a boolean or a number. If a Boolean is passed, then the component takes a flexible inset and adjusts its children according to the device. If a number is passed, then it provides a fixed inset in the chosen direction.
 
 - `safeArea`: Apply safe padding to all edges.
 - `safeAreaX`: Apply safe padding to x direction.
@@ -17,7 +17,7 @@ Internally, NativeBase uses [useSafeAreaInsets](https://docs.expo.io/versions/la
 
 :::info
 
-SafeAreaView props can only be applied on [Box](box.md) as of now. To make you App SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
+SafeAreaView props can only be applied on [Box](box.md) as of now. To make your App SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
 
 :::
 
@@ -73,7 +73,7 @@ export function Example() {
 
 ### Using Hook
 
-If you want to add the SafeAreaView props to other components, you can use the hook. Since, `SafeAreaView` props add relevant padding to the components, you will need to pass the padding manually that you are applying to the component for it to return the SafeArea adjusted padding.
+If you want to add the SafeAreaView props to other components, you can use the hook. Since `SafeAreaView` props add relevant padding to the components, you will need to pass the padding manually that you are applying to the component for it to return the SafeArea adjusted padding.
 
 ```jsx isLive=true
 import React from 'react';

--- a/docs/3.1.x/nativebase-factory.md
+++ b/docs/3.1.x/nativebase-factory.md
@@ -147,5 +147,5 @@ export function Example() {
 
 | Name           | Type            | Description                                                                   | Default |
 | -------------- | --------------- | ----------------------------------------------------------------------------- | ------- |
-| component      | React component | Original component to be passed on which nativebase props have to be applied. | -       |
+| component      | React component | Original component to be passed on which NativeBase props have to be applied. | -       |
 | componentTheme | Object          | This object can include `baseStyle`, `sizes`, `variants`, `defaultProps`      | -       |

--- a/docs/3.1.x/safe-area-view-props.md
+++ b/docs/3.1.x/safe-area-view-props.md
@@ -3,7 +3,7 @@ id: safe-area-view-props
 title: SafeAreaView Props
 ---
 
-To make your components respect the [SafeAreaView](https://reactnative.dev/docs/safeareaview) of the device, we have provided some props that you can use with Box component. They apply a safe padding to your component in the parts decided by the passed props. These props accept either a boolean or a number. If boolean is passed then component takes flexible inset and adjusts its children according to the the device. If a number is passed then it provides a fixed inset in the chosen direction.
+To make your components respect the [SafeAreaView](https://reactnative.dev/docs/safeareaview) of the device, we have provided some props that you can use with Box component. They apply a safe padding to your component in the parts decided by the passed props. These props accept either a boolean or a number. If a Boolean is passed, then the component takes a flexible inset and adjusts its children according to the device. If a number is passed, then it provides a fixed inset in the chosen direction.
 
 - `safeArea`: Apply safe padding to all edges.
 - `safeAreaX`: Apply safe padding to x direction.
@@ -17,7 +17,7 @@ Internally, NativeBase uses [useSafeAreaInsets](https://docs.expo.io/versions/la
 
 :::info
 
-SafeAreaView props can only be applied on [Box](box.md) as of now. To make you App SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
+SafeAreaView props can only be applied on [Box](box.md) as of now. To make your App SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
 
 :::
 
@@ -73,7 +73,7 @@ export function Example() {
 
 ### Using Hook
 
-If you want to add the SafeAreaView props to other components, you can use the hook. Since, `SafeAreaView` props add relevant padding to the components, you will need to pass the padding manually that you are applying to the component for it to return the SafeArea adjusted padding.
+If you want to add the SafeAreaView props to other components, you can use the hook. Since `SafeAreaView` props add relevant padding to the components, you will need to pass the padding manually that you are applying to the component for it to return the SafeArea adjusted padding.
 
 ```jsx isLive=true
 import React from 'react';

--- a/docs/3.2.x/nativebase-factory.md
+++ b/docs/3.2.x/nativebase-factory.md
@@ -37,5 +37,5 @@ import { Factory } from 'native-base';
 
 | Name           | Type            | Description                                                                   | Default |
 | -------------- | --------------- | ----------------------------------------------------------------------------- | ------- |
-| component      | React component | Original component to be passed on which nativebase props have to be applied. | -       |
+| component      | React component | Original component to be passed on which NativeBase props have to be applied. | -       |
 | componentTheme | Object          | This object can include `baseStyle`, `sizes`, `variants`, `defaultProps`      | -       |

--- a/docs/3.2.x/safe-area-view-props.md
+++ b/docs/3.2.x/safe-area-view-props.md
@@ -3,7 +3,7 @@ id: safe-area-view-props
 title: SafeAreaView Props
 ---
 
-To make your components respect the [SafeAreaView](https://reactnative.dev/docs/safeareaview) of the device, we have provided some props that you can use with Box component. They apply a safe padding to your component in the parts decided by the passed props. These props accept either a boolean or a number. If boolean is passed then component takes flexible inset and adjusts its children according to the the device. If a number is passed then it provides a fixed inset in the chosen direction.
+To make your components respect the [SafeAreaView](https://reactnative.dev/docs/safeareaview) of the device, we have provided some props that you can use with Box component. They apply a safe padding to your component in the parts decided by the passed props. These props accept either a boolean or a number. If a Boolean is passed, then the component takes a flexible inset and adjusts its children according to the device. If a number is passed, then it provides a fixed inset in the chosen direction.
 
 - `safeArea`: Apply safe padding to all edges.
 - `safeAreaX`: Apply safe padding to x direction.
@@ -17,7 +17,7 @@ Internally, NativeBase uses [useSafeAreaInsets](https://docs.expo.io/versions/la
 
 :::info
 
-SafeAreaView props can only be applied on [Box](box.md) as of now. To make you App SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
+SafeAreaView props can only be applied on [Box](box.md) as of now. To make your App SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
 
 :::
 
@@ -73,7 +73,7 @@ export function Example() {
 
 ### Using Hook
 
-If you want to add the SafeAreaView props to other components, you can use the hook. Since, `SafeAreaView` props add relevant padding to the components, you will need to pass the padding manually that you are applying to the component for it to return the SafeArea adjusted padding.
+If you want to add the SafeAreaView props to other components, you can use the hook. Since `SafeAreaView` props add relevant padding to the components, you will need to pass the padding manually that you are applying to the component for it to return the SafeArea adjusted padding.
 
 ```jsx isLive
 import React from 'react';

--- a/docs/3.3.x/nativebase-factory.md
+++ b/docs/3.3.x/nativebase-factory.md
@@ -37,5 +37,5 @@ import { Factory } from 'native-base';
 
 | Name           | Type            | Description                                                                   | Default |
 | -------------- | --------------- | ----------------------------------------------------------------------------- | ------- |
-| component      | React component | Original component to be passed on which nativebase props have to be applied. | -       |
+| component      | React component | Original component to be passed on which NativeBase props have to be applied. | -       |
 | componentTheme | Object          | This object can include `baseStyle`, `sizes`, `variants`, `defaultProps`      | -       |

--- a/docs/3.3.x/safe-area-view-props.md
+++ b/docs/3.3.x/safe-area-view-props.md
@@ -3,7 +3,7 @@ id: safe-area-view-props
 title: SafeAreaView Props
 ---
 
-To make your components respect the [SafeAreaView](https://reactnative.dev/docs/safeareaview) of the device, we have provided some props that you can use with Box component. They apply a safe padding to your component in the parts decided by the passed props. These props accept either a boolean or a number. If boolean is passed then component takes flexible inset and adjusts its children according to the the device. If a number is passed then it provides a fixed inset in the chosen direction.
+To make your components respect the [SafeAreaView](https://reactnative.dev/docs/safeareaview) of the device, we have provided some props that you can use with Box component. They apply a safe padding to your component in the parts decided by the passed props. These props accept either a boolean or a number. If a Boolean is passed, then the component takes a flexible inset and adjusts its children according to the device. If a number is passed, then it provides a fixed inset in the chosen direction.
 
 - `safeArea`: Apply safe padding to all edges.
 - `safeAreaX`: Apply safe padding to x direction.
@@ -17,7 +17,7 @@ Internally, NativeBase uses [useSafeAreaInsets](https://docs.expo.io/versions/la
 
 :::info
 
-SafeAreaView props can only be applied on [Box](box.md) as of now. To make you App SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
+SafeAreaView props can only be applied on [Box](box.md) as of now. To make your App SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
 
 :::
 
@@ -73,7 +73,7 @@ export function Example() {
 
 ### Using Hook
 
-If you want to add the SafeAreaView props to other components, you can use the hook. Since, `SafeAreaView` props add relevant padding to the components, you will need to pass the padding manually that you are applying to the component for it to return the SafeArea adjusted padding.
+If you want to add the SafeAreaView props to other components, you can use the hook. Since `SafeAreaView` props add relevant padding to the components, you will need to pass the padding manually that you are applying to the component for it to return the SafeArea adjusted padding.
 
 ```jsx isLive=true
 import React from 'react';

--- a/docs/3.4.x/nativebase-factory.md
+++ b/docs/3.4.x/nativebase-factory.md
@@ -37,5 +37,5 @@ import { Factory } from "native-base";
 
 | Name           | Type            | Description                                                                   | Default |
 | -------------- | --------------- | ----------------------------------------------------------------------------- | ------- |
-| component      | React component | Original component to be passed on which nativebase props have to be applied. | -       |
+| component      | React component | Original component to be passed on which NativeBase props have to be applied. | -       |
 | componentTheme | Object          | This object can include `baseStyle`, `sizes`, `variants`, `defaultProps`      | -       |

--- a/docs/3.4.x/safe-area-view-props.md
+++ b/docs/3.4.x/safe-area-view-props.md
@@ -3,7 +3,7 @@ id: safe-area-view-props
 title: SafeAreaView Props
 ---
 
-To make your components respect the [SafeAreaView](https://reactnative.dev/docs/safeareaview) of the device, we have provided some props that you can use with Box component. They apply a safe padding to your component in the parts decided by the passed props. These props accept either a boolean or a number. If boolean is passed then component takes flexible inset and adjusts its children according to the the device. If a number is passed then it provides a fixed inset in the chosen direction.
+To make your components respect the [SafeAreaView](https://reactnative.dev/docs/safeareaview) of the device, we have provided some props that you can use with Box component. They apply a safe padding to your component in the parts decided by the passed props. These props accept either a boolean or a number. If a Boolean is passed, then the component takes a flexible inset and adjusts its children according to the device. If a number is passed, then it provides a fixed inset in the chosen direction.
 
 - `safeArea`: Apply safe padding to all edges.
 - `safeAreaX`: Apply safe padding to x direction.
@@ -17,7 +17,7 @@ Internally, NativeBase uses [useSafeAreaInsets](https://docs.expo.io/versions/la
 
 :::info
 
-SafeAreaView props can only be applied on [Box](box.md) as of now. To make your app SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
+SafeAreaView props can only be applied on [Box](box.md) as of now. To make your App SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
 
 :::
 
@@ -73,7 +73,7 @@ export function Example() {
 
 ### Using Hook
 
-If you want to add the SafeAreaView props to other components, you can use the hook. Since, `SafeAreaView` props add relevant padding to the components, you will need to pass the padding manually that you are applying to the component for it to return the SafeArea adjusted padding.
+If you want to add the SafeAreaView props to other components, you can use the hook. Since `SafeAreaView` props add relevant padding to the components, you will need to pass the padding manually that you are applying to the component for it to return the SafeArea adjusted padding.
 
 ```jsx isLive=true
 import React from "react";

--- a/docs/next/nativebase-factory.md
+++ b/docs/next/nativebase-factory.md
@@ -37,5 +37,5 @@ import { Factory } from "native-base";
 
 | Name           | Type            | Description                                                                   | Default |
 | -------------- | --------------- | ----------------------------------------------------------------------------- | ------- |
-| component      | React component | Original component to be passed on which nativebase props have to be applied. | -       |
+| component      | React component | Original component to be passed on which NativeBase props have to be applied. | -       |
 | componentTheme | Object          | This object can include `baseStyle`, `sizes`, `variants`, `defaultProps`      | -       |

--- a/docs/next/safe-area-view-props.md
+++ b/docs/next/safe-area-view-props.md
@@ -3,7 +3,7 @@ id: safe-area-view-props
 title: SafeAreaView Props
 ---
 
-To make your components respect the [SafeAreaView](https://reactnative.dev/docs/safeareaview) of the device, we have provided some props that you can use with Box component. They apply a safe padding to your component in the parts decided by the passed props. These props accept either a boolean or a number. If boolean is passed then component takes flexible inset and adjusts its children according to the the device. If a number is passed then it provides a fixed inset in the chosen direction.
+To make your components respect the [SafeAreaView](https://reactnative.dev/docs/safeareaview) of the device, we have provided some props that you can use with Box component. They apply a safe padding to your component in the parts decided by the passed props. These props accept either a boolean or a number. If a Boolean is passed, then the component takes a flexible inset and adjusts its children according to the device. If a number is passed, then it provides a fixed inset in the chosen direction.
 
 - `safeArea`: Apply safe padding to all edges.
 - `safeAreaX`: Apply safe padding to x direction.
@@ -17,7 +17,7 @@ Internally, NativeBase uses [useSafeAreaInsets](https://docs.expo.io/versions/la
 
 :::info
 
-SafeAreaView props can only be applied on [Box](box.md) as of now. To make your app SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
+SafeAreaView props can only be applied on [Box](box.md) as of now. To make your App SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
 
 :::
 
@@ -73,7 +73,7 @@ export function Example() {
 
 ### Using Hook
 
-If you want to add the SafeAreaView props to other components, you can use the hook. Since, `SafeAreaView` props add relevant padding to the components, you will need to pass the padding manually that you are applying to the component for it to return the SafeArea adjusted padding.
+If you want to add the SafeAreaView props to other components, you can use the hook. Since `SafeAreaView` props add relevant padding to the components, you will need to pass the padding manually that you are applying to the component for it to return the SafeArea adjusted padding.
 
 ```jsx isLive=true
 import React from "react";


### PR DESCRIPTION
Old Content -
If boolean is passed then component takes flexible inset and adjusts its children according to the the device.If a number is passed then it provides a fixed inset in the chosen direction.
To make you App SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
Since, SafeAreaView props add relevant padding to the components, 
New Content -
If a Boolean is passed, then the component takes a flexible inset and adjusts its children according to the device. If a number is passed, then it provides a fixed inset in the chosen direction.
To make your App SafeArea safe, just wrap your app with a Box and pass safeArea props to it.
Since SafeAreaView props add relevant padding to the components,