### PR TITLE
Updated Content Changes in badge

### DIFF
--- a/docs/3.3.x/badge.md
+++ b/docs/3.3.x/badge.md
@@ -5,7 +5,7 @@ title: Badge
 
 import { ComponentTheme } from '../src/components';
 
-`Badges` allows the highlight of an item’s status. This provides quick recognition.
+`Badges` allow the highlighting of an item’s status. This provides quick recognition.
 
 ```jsx isShowcase
 import React from 'react';

--- a/docs/3.4.x/badge.md
+++ b/docs/3.4.x/badge.md
@@ -5,7 +5,7 @@ title: Badge
 
 import { ComponentTheme } from '../src/components';
 
-`Badges` allows the highlight of an item’s status. This provides quick recognition.
+`Badges` allow the highlighting of an item’s status. This provides quick recognition.
 
 ```jsx isShowcase
 import React from 'react';

--- a/docs/next/badge.md
+++ b/docs/next/badge.md
@@ -5,7 +5,7 @@ title: Badge
 
 import { ComponentTheme } from '../src/components';
 
-`Badges` allows the highlight of an item’s status. This provides quick recognition.
+`Badges` allow the highlighting of an item’s status. This provides quick recognition.
 
 ```jsx isShowcase
 import React from 'react';


### PR DESCRIPTION
Old Content - 
`Badges` allows the highlight of an item’s status.
CheckOut the default theme of badge
New Content -
`Badges` allow the highlighting of an item’s status.
Check out the default theme of badge