### PR TITLE
Updated Content Changes in Toast

### DIFF
--- a/docs/3.0.x/toast.md
+++ b/docs/3.0.x/toast.md
@@ -5,7 +5,7 @@ title: Toast
 
 import { ComponentTheme } from '../../src/components';
 
-`Toast` is used to show alerts on top of an overlay. `Toast` will close itself when the close button is clicked, or after a timeout — the default is 5 seconds. The toast component is used to give feeback to users after an action has taken place.
+`Toast` is used to show alerts on top of an overlay. `Toast` will close itself when the close button is clicked on or after a timeout — the default is 5 seconds. The toast component is used to give feeback to users after an action has taken place.
 
 Toasts can be configured to appear at either the top or the bottom of an application window, and it is possible to have more than one toast onscreen at a time.
 
@@ -39,7 +39,7 @@ Display a custom component instead of the default Toast UI.
 
 ### Closing Toasts
 
-Toasts can be closed imperatively, individually (via the close instance method) or all together (via the closeAll instance method).
+Toasts can be closed imperatively, individually (via the close instance method), or all together (via the closeAll instance method).
 
 ```ComponentSnackPlayer path=composites,Toast,CloseToast.tsx
 
@@ -56,7 +56,7 @@ You can use status to change the color of your toasts.
 
 ### Preventing Duplicate Toast
 
-In some cases you might need to prevent duplicate of specific toasts. To achieve you need to pass an id and use the toast.isActive method to determine when to call toast.show(...).
+In some cases, you might need to prevent duplicates of specific toasts. To achieve this, you need to pass an id and use the toast.isActive method to determine when to call toast.show(...).
 
 ```ComponentSnackPlayer path=composites,Toast,PreventDuplicate.tsx
 
@@ -64,7 +64,7 @@ In some cases you might need to prevent duplicate of specific toasts. To achieve
 
 ## Props
 
-Below props can be passed while calling toast.show.
+The following props can be passed while calling toast.show.
 
 ```ComponentPropTable path=composites,Toast,ToastDummy.tsx
 

--- a/docs/3.1.x/toast.md
+++ b/docs/3.1.x/toast.md
@@ -5,7 +5,7 @@ title: Toast
 
 import { ComponentTheme } from '../../src/components';
 
-`Toast` is used to show alerts on top of an overlay. `Toast` will close itself when the close button is clicked, or after a timeout — the default is 5 seconds. The toast component is used to give feeback to users after an action has taken place.
+`Toast` is used to show alerts on top of an overlay. `Toast` will close itself when the close button is clicked on or after a timeout — the default is 5 seconds. The toast component is used to give feeback to users after an action has taken place.
 
 Toasts can be configured to appear at either the top or the bottom of an application window, and it is possible to have more than one toast onscreen at a time.
 
@@ -39,7 +39,7 @@ Display a custom component instead of the default Toast UI.
 
 ### Closing Toasts
 
-Toasts can be closed imperatively, individually (via the close instance method) or all together (via the closeAll instance method).
+Toasts can be closed imperatively, individually (via the close instance method), or all together (via the closeAll instance method).
 
 ```ComponentSnackPlayer path=composites,Toast,CloseToast.tsx
 
@@ -56,7 +56,7 @@ You can use status to change the color of your toasts.
 
 ### Preventing Duplicate Toast
 
-In some cases you might need to prevent duplicate of specific toasts. To achieve you need to pass an id and use the toast.isActive method to determine when to call toast.show(...).
+In some cases, you might need to prevent duplicates of specific toasts. To achieve this, you need to pass an id and use the toast.isActive method to determine when to call toast.show(...).
 
 ```ComponentSnackPlayer path=composites,Toast,PreventDuplicate.tsx
 
@@ -64,7 +64,7 @@ In some cases you might need to prevent duplicate of specific toasts. To achieve
 
 ### Standalone Toast
 
-You can use standalone toast where you don't have access to `useToast` hook. e.g. in a different file, out of a React component.
+You can use standalone toast where you don't have access to `useToast` hook, for example, in a different file, out of a React component.
 
 ```ComponentSnackPlayer path=composites,Toast,StandaloneToast.tsx
 
@@ -72,7 +72,7 @@ You can use standalone toast where you don't have access to `useToast` hook. e.g
 
 ## Props
 
-Below props can be passed while calling toast.show.
+The following props can be passed while calling toast.show.
 
 ```ComponentPropTable path=composites,Toast,ToastDummy.tsx
 

--- a/docs/3.2.x/toast.md
+++ b/docs/3.2.x/toast.md
@@ -5,7 +5,7 @@ title: Toast
 
 import { ComponentTheme } from '../../src/components';
 
-`Toast` is used to show alerts on top of an overlay. `Toast` will close itself when the close button is clicked, or after a timeout — the default is 5 seconds. The toast component is used to give feeback to users after an action has taken place.
+`Toast` is used to show alerts on top of an overlay. `Toast` will close itself when the close button is clicked on or after a timeout — the default is 5 seconds. The toast component is used to give feeback to users after an action has taken place.
 
 Toasts can be configured to appear at either the top or the bottom of an application window, and it is possible to have more than one toast onscreen at a time.
 
@@ -39,7 +39,7 @@ Display a custom component instead of the default Toast UI.
 
 ### Closing Toasts
 
-Toasts can be closed imperatively, individually (via the close instance method) or all together (via the closeAll instance method).
+Toasts can be closed imperatively, individually (via the close instance method), or all together (via the closeAll instance method).
 
 ```ComponentSnackPlayer path=components,composites,Toast,CloseToast.tsx
 
@@ -56,7 +56,7 @@ You can use status to change the color of your toasts.
 
 ### Preventing Duplicate Toast
 
-In some cases you might need to prevent duplicate of specific toasts. To achieve you need to pass an id and use the toast.isActive method to determine when to call toast.show(...).
+In some cases, you might need to prevent duplicates of specific toasts. To achieve this, you need to pass an id and use the toast.isActive method to determine when to call toast.show(...).
 
 ```ComponentSnackPlayer path=components,composites,Toast,PreventDuplicate.tsx
 
@@ -64,7 +64,7 @@ In some cases you might need to prevent duplicate of specific toasts. To achieve
 
 ### Standalone Toast
 
-You can use standalone toast where you don't have access to `useToast` hook. e.g. in a different file, out of a React component.
+You can use standalone toast where you don't have access to `useToast` hook, for example, in a different file, out of a React component.
 
 ```ComponentSnackPlayer path=components,composites,Toast,StandaloneToast.tsx
 
@@ -72,7 +72,7 @@ You can use standalone toast where you don't have access to `useToast` hook. e.g
 
 ## Props
 
-Below props can be passed while calling toast.show.
+The following props can be passed while calling toast.show.
 
 ```ComponentPropTable path=composites,Toast,ToastDummy.tsx
 

--- a/docs/3.3.x/toast.md
+++ b/docs/3.3.x/toast.md
@@ -5,7 +5,7 @@ title: Toast
 
 import { ComponentTheme } from '../src/components';
 
-`Toast` display alerts on top of an overlay. The `Toast` terminates itself when the close button is clicked or after a preset timeout — the default is 5 seconds. The component also allows users to give feedback when an action is completed.
+`Toast` displays alerts on top of an overlay. The `Toast` terminates itself when the close button is clicked on or after a preset timeout — the default is 5 seconds. The component also allows users to give feedback when an action is completed.
 
 Toasts can also be configured to pop up at different areas of the application window—top or bottom. More than one instance of toast can be present onscreen at one time.
 
@@ -61,7 +61,7 @@ Display a custom component instead of the default Toast UI.
 
 ### Closing Toasts
 
-Toasts can be closed imperatively, individually (via the close instance method) or all together (via the closeAll instance method).
+Toasts can be closed imperatively, individually (via the close instance method), or all together (via the closeAll instance method).
 
 ```ComponentSnackPlayer path=components,composites,Toast,CloseToast.tsx
 
@@ -78,7 +78,7 @@ You can use status to change the color of your toasts.
 
 ### Preventing Duplicate Toast
 
-In some cases you might need to prevent duplicate of specific toasts. To achieve you need to pass an id and use the toast.isActive method to determine when to call toast.show(...).
+In some cases, you might need to prevent duplicates of specific toasts. To achieve this, you need to pass an id and use the toast.isActive method to determine when to call toast.show(...).
 
 ```ComponentSnackPlayer path=components,composites,Toast,PreventDuplicate.tsx
 
@@ -86,7 +86,7 @@ In some cases you might need to prevent duplicate of specific toasts. To achieve
 
 ### Standalone Toast
 
-You can use standalone toast where you don't have access to `useToast` hook. e.g. in a different file, out of a React component.
+You can use standalone toast where you don't have access to `useToast` hook, for example, in a different file, out of a React component.
 
 ```ComponentSnackPlayer path=components,composites,Toast,StandaloneToast.tsx
 
@@ -94,7 +94,7 @@ You can use standalone toast where you don't have access to `useToast` hook. e.g
 
 ## Props
 
-Below props can be passed while calling toast.show.
+The following props can be passed while calling toast.show.
 
 ```ComponentPropTable path=composites,Toast,ToastDummy.tsx
 

--- a/docs/3.4.x/toast.md
+++ b/docs/3.4.x/toast.md
@@ -5,7 +5,7 @@ title: Toast
 
 import { ComponentTheme } from '../src/components';
 
-`Toast` display alerts on top of an overlay. The `Toast` terminates itself when the close button is clicked or after a preset timeout — the default is 5 seconds. The component also allows users to give feedback when an action is completed.
+`Toast` displays alerts on top of an overlay. The `Toast` terminates itself when the close button is clicked or after a preset timeout — the default is 5 seconds. The component also allows users to give feedback when an action is completed.
 
 Toasts can also be configured to pop up at different areas of the application window—top or bottom. More than one instance of toast can be present onscreen at one time.
 
@@ -61,7 +61,7 @@ Display a custom component instead of the default Toast UI.
 
 ### Closing Toasts
 
-Toasts can be closed imperatively, individually (via the close instance method) or all together (via the closeAll instance method).
+Toasts can be closed imperatively, individually (via the close instance method), or all together (via the closeAll instance method).
 
 ```ComponentSnackPlayer path=components,composites,Toast,CloseToast.tsx
 
@@ -69,7 +69,7 @@ Toasts can be closed imperatively, individually (via the close instance method) 
 
 ### Status & Variant Recipes
 
-You create custom Toasts that responds to different status and variants, similarly like the `Alert` component. Below is a recipe that you can try out.
+You can create custom Toasts that respond to different statuses and variants, similar to the Alert component. Below is a recipe that you can try out.
 
 ```ComponentSnackPlayer path=components,composites,Toast,VariantRecipies.tsx
 
@@ -77,7 +77,7 @@ You create custom Toasts that responds to different status and variants, similar
 
 ### Preventing Duplicate Toast
 
-In some cases you might need to prevent duplicate of specific toasts. To achieve you need to pass an id and use the toast.isActive method to determine when to call toast.show(...).
+In some cases, you might need to prevent duplicates of specific toasts. To achieve this, you need to pass an id and use the toast.isActive method to determine when to call toast.show(...).
 
 ```ComponentSnackPlayer path=components,composites,Toast,PreventDuplicate.tsx
 
@@ -85,7 +85,7 @@ In some cases you might need to prevent duplicate of specific toasts. To achieve
 
 ### Standalone Toast
 
-You can use standalone toast where you don't have access to `useToast` hook. e.g. in a different file, out of a React component.
+You can use standalone toast where you don't have access to `useToast` hook, for example, in a different file, out of a React component.
 
 ```ComponentSnackPlayer path=components,composites,Toast,StandaloneToast.tsx
 
@@ -93,7 +93,7 @@ You can use standalone toast where you don't have access to `useToast` hook. e.g
 
 ## Props
 
-Below props can be passed while calling toast.show.
+The following props can be passed while calling toast.show.
 
 ```ComponentPropTable path=composites,Toast,ToastDummy.tsx
 

--- a/docs/next/toast.md
+++ b/docs/next/toast.md
@@ -5,7 +5,7 @@ title: Toast
 
 import { ComponentTheme } from '../src/components';
 
-`Toast` display alerts on top of an overlay. The `Toast` terminates itself when the close button is clicked or after a preset timeout — the default is 5 seconds. The component also allows users to give feedback when an action is completed.
+`Toast` displays alerts on top of an overlay. The `Toast` terminates itself when the close button is clicked on or after a preset timeout — the default is 5 seconds. The component also allows users to give feedback when an action is completed.
 
 Toasts can also be configured to pop up at different areas of the application window—top or bottom. More than one instance of toast can be present onscreen at one time.
 
@@ -61,7 +61,7 @@ Display a custom component instead of the default Toast UI.
 
 ### Closing Toasts
 
-Toasts can be closed imperatively, individually (via the close instance method) or all together (via the closeAll instance method).
+Toasts can be closed imperatively, individually (via the close instance method), or all together (via the closeAll instance method).
 
 ```ComponentSnackPlayer path=components,composites,Toast,CloseToast.tsx
 
@@ -69,7 +69,7 @@ Toasts can be closed imperatively, individually (via the close instance method) 
 
 ### Status & Variant Recipes
 
-You create custom Toasts that responds to different status and variants, similarly like the `Alert` component. Below is a recipe that you can try out.
+You can create custom Toasts that respond to different statuses and variants, similar to the Alert component. Below is a recipe that you can try out.
 
 ```ComponentSnackPlayer path=components,composites,Toast,VariantRecipies.tsx
 
@@ -77,7 +77,7 @@ You create custom Toasts that responds to different status and variants, similar
 
 ### Preventing Duplicate Toast
 
-In some cases you might need to prevent duplicate of specific toasts. To achieve you need to pass an id and use the toast.isActive method to determine when to call toast.show(...).
+In some cases, you might need to prevent duplicates of specific toasts. To achieve this, you need to pass an id and use the toast.isActive method to determine when to call toast.show(...).
 
 ```ComponentSnackPlayer path=components,composites,Toast,PreventDuplicate.tsx
 
@@ -85,7 +85,7 @@ In some cases you might need to prevent duplicate of specific toasts. To achieve
 
 ### Standalone Toast
 
-You can use standalone toast where you don't have access to `useToast` hook. e.g. in a different file, out of a React component.
+You can use standalone toast where you don't have access to `useToast` hook, for example, in a different file, out of a React component.
 
 ```ComponentSnackPlayer path=components,composites,Toast,StandaloneToast.tsx
 


### PR DESCRIPTION
**Old Content -** 
`Toast` display alerts on top of an overlay
when the close button is clicked or after a preset timeout
individually (via the close instance method) or
You create custom Toasts that responds to different status and variants, similarly like the `Alert` component. Below is a recipe that you can try out.
In some cases you might need to prevent duplicate of specific toasts. To achieve you
`useToast` hook. e.g.
Below props can be passed while calling toast
Checkout the default theme of toast
**New Content -**
`Toast` displays alerts on top of an overlay
when the close button is clicked on or after a preset timeout
individually (via the close instance method), or
You can create custom Toasts that respond to different statuses and variants, similar to the Alert component. Below is a recipe that you can try out.
In some cases, you might need to prevent duplicates of specific toasts. To achieve this, you
`useToast` hook, for example, in
The following props can be passed while calling toast
Check out the default theme of toast