### PR TITLE
Updated Content Changes in 3.2.0 from 3.x

### DIFF
--- a/docs/3.2.x/migration/v3xtov32.mdx
+++ b/docs/3.2.x/migration/v3xtov32.mdx
@@ -3,13 +3,13 @@ id: migration-guide-three-point-two
 title: Upgrading to 3.2.0 from 3.x
 ---
 
-As we continue to improve NativeBase v3 we got a lot of feature requests and we also revamped our theme to make it more consistent, easy to understand, optimized and promote good practices while writing code.
+As we continued to improve NativeBase v3, we got a lot of feature requests and we also revamped our theme to make it more consistent, easy to understand, and optimized to promote good practices while writing code.
 
-To do that we had to make some changes to our theme in `v3.2.0`. These are breaking changes if you are using some of the tokens in your project. To make it easy for you to upgrade, we are providing three options:
+In order to do this, we had to make some changes to our theme in `v3.2.0`. These are breaking changes if you are using some of the tokens in your project. To make it easy for you to upgrade, we are providing three options:
 
-## Extend previous version's theme for backward compatibility
+##  Extend Previous Version's Theme for Backward Compatibility
 
-You need to add `v3CompatibleTheme` to your `NativeBaseProvider` which preserves all the old token that were changed or removed in v3.2.0.
+You need to add `v3CompatibleTheme` to your `NativeBaseProvider` which preserves all the old tokens that were changed or removed in v3.2.0.
 
 ```jsx
 import {
@@ -34,8 +34,8 @@ If you are updating from 3.1.x to 3.2.x in a Next.js project, you might need to 
 
 ### Updating next.config.js/ts
 
-- Now need to include only react-native-web and native-base in transplie-modules
-- No need of webpack config just add withFonts(from next-fonts) and withExpo(from @expo/next-adapter)
+- Now need to include only react-native-web and native-base in transplie-modules.
+- No need of webpack config just add withFonts(from next-fonts) and withExpo(from @expo/next-adapter).
 
 ```jsx {5-22,27-40}
 const withFonts = require('next-fonts');
@@ -212,9 +212,9 @@ Below is a rough account of the breaking API changes as well as the minimal chan
 
 We have introduced [strict mode](../strict-mode) in `v3.2.0` which is `off` by default. If you don't want to have strict mode, step 1 is enough. If you want to comply with the strict mode, you also need to do these:
 
-1.  All utility props which take theme tokens as values, now take only string values as a valid type
+1.  All utility props which take theme tokens as values, now take only string values as a valid type.
 
-This means that if you pass a number value which is supposed to be a theme token, into a utility prop, then it will be treated as invalid and based on you strict mode config will show you an error or a warning.
+This means that if you pass a number value that is supposed to be a theme token into a utility prop, then it will be treated as invalid and based on your strict mode config will show you an error or a warning.
 
 ```js
 // Incorrect Way to pass theme tokens to utility props

--- a/docs/3.3.x/migration/v3xtov32.mdx
+++ b/docs/3.3.x/migration/v3xtov32.mdx
@@ -3,13 +3,13 @@ id: migration-guide-three-point-two
 title: Upgrading to 3.2.0 from 3.x
 ---
 
-As we continue to improve NativeBase v3 we got a lot of feature requests and we also revamped our theme to make it more consistent, easy to understand, optimized and promote good practices while writing code.
+As we continued to improve NativeBase v3, we got a lot of feature requests and we also revamped our theme to make it more consistent, easy to understand, and optimized to promote good practices while writing code.
 
-To do that we had to make some changes to our theme in `v3.2.0`. These are breaking changes if you are using some of the tokens in your project. To make it easy for you to upgrade, we are providing three options:
+In order to do this, we had to make some changes to our theme in `v3.2.0`. These are breaking changes if you are using some of the tokens in your project. To make it easy for you to upgrade, we are providing three options:
 
-## Extend previous version's theme for backward compatibility
+##  Extend Previous Version's Theme for Backward Compatibility
 
-You need to add `v3CompatibleTheme` to your `NativeBaseProvider` which preserves all the old token that were changed or removed in v3.2.0.
+You need to add `v3CompatibleTheme` to your `NativeBaseProvider` which preserves all the old tokens that were changed or removed in v3.2.0.
 
 ```jsx
 import {
@@ -34,8 +34,8 @@ If you are updating from 3.1.x to 3.2.x in a Next.js project, you might need to 
 
 ### Updating next.config.js/ts
 
-- Now need to include only react-native-web and native-base in transplie-modules
-- No need of webpack config just add withFonts(from next-fonts) and withExpo(from @expo/next-adapter)
+- Now need to include only react-native-web and native-base in transplie-modules. 
+- No need of webpack config just add withFonts(from next-fonts) and withExpo(from @expo/next-adapter).
 
 ```jsx {5-22,27-40}
 const withFonts = require('next-fonts');
@@ -212,9 +212,9 @@ Below is a rough account of the breaking API changes as well as the minimal chan
 
 We have introduced [strict mode](../strict-mode) in `v3.2.0` which is `off` by default. If you don't want to have strict mode, step 1 is enough. If you want to comply with the strict mode, you also need to do these:
 
-1.  All utility props which take theme tokens as values, now take only string values as a valid type
+1.  All utility props which take theme tokens as values, now take only string values as a valid type.
 
-This means that if you pass a number value which is supposed to be a theme token, into a utility prop, then it will be treated as invalid and based on you strict mode config will show you an error or a warning.
+This means that if you pass a number value that is supposed to be a theme token into a utility prop, then it will be treated as invalid and based on your strict mode config will show you an error or a warning.
 
 ```js
 // Incorrect Way to pass theme tokens to utility props

--- a/docs/3.4.x/migration/v3xtov32.mdx
+++ b/docs/3.4.x/migration/v3xtov32.mdx
@@ -3,13 +3,13 @@ id: migration-guide-three-point-two
 title: Upgrading to 3.2.0 from 3.x
 ---
 
-As we continue to improve NativeBase v3 we got a lot of feature requests and we also revamped our theme to make it more consistent, easy to understand, optimized and promote good practices while writing code.
+As we continued to improve NativeBase v3, we got a lot of feature requests and we also revamped our theme to make it more consistent, easy to understand, and optimized to promote good practices while writing code.
 
-To do that we had to make some changes to our theme in `v3.2.0`. These are breaking changes if you are using some of the tokens in your project. To make it easy for you to upgrade, we are providing three options:
+In order to do this, we had to make some changes to our theme in `v3.2.0`. These are breaking changes if you are using some of the tokens in your project. To make it easy for you to upgrade, we are providing three options:
 
-## Extend previous version's theme for backward compatibility
+##   Extend Previous Version's Theme for Backward Compatibility
 
-You need to add `v3CompatibleTheme` to your `NativeBaseProvider` which preserves all the old token that were changed or removed in v3.2.0.
+You need to add `v3CompatibleTheme` to your `NativeBaseProvider` which preserves all the old tokens that were changed or removed in v3.2.0.
 
 ```jsx
 import {
@@ -34,8 +34,8 @@ If you are updating from 3.1.x to 3.2.x in a Next.js project, you might need to 
 
 ### Updating next.config.js/ts
 
-- Now need to include only react-native-web and native-base in transplie-modules
-- No need of webpack config just add withFonts(from next-fonts) and withExpo(from @expo/next-adapter)
+- Now need to include only react-native-web and native-base in transplie-modules.
+- No need of webpack config just add withFonts(from next-fonts) and withExpo(from @expo/next-adapter).
 
 ```jsx {5-22,27-40}
 const withFonts = require('next-fonts');
@@ -212,9 +212,9 @@ Below is a rough account of the breaking API changes as well as the minimal chan
 
 We have introduced [strict mode](../strict-mode) in `v3.2.0` which is `off` by default. If you don't want to have strict mode, step 1 is enough. If you want to comply with the strict mode, you also need to do these:
 
-1.  All utility props which take theme tokens as values, now take only string values as a valid type
+1.  All utility props which take theme tokens as values, now take only string values as a valid type.
 
-This means that if you pass a number value which is supposed to be a theme token, into a utility prop, then it will be treated as invalid and based on you strict mode config will show you an error or a warning.
+This means that if you pass a number value that is supposed to be a theme token into a utility prop, then it will be treated as invalid and based on your strict mode config will show you an error or a warning.
 
 ```js
 // Incorrect Way to pass theme tokens to utility props

--- a/docs/next/migration/v3xtov32.mdx
+++ b/docs/next/migration/v3xtov32.mdx
@@ -3,13 +3,13 @@ id: migration-guide-three-point-two
 title: Upgrading to 3.2.0 from 3.x
 ---
 
-As we continue to improve NativeBase v3 we got a lot of feature requests and we also revamped our theme to make it more consistent, easy to understand, optimized and promote good practices while writing code.
+As we continued to improve NativeBase v3, we got a lot of feature requests and we also revamped our theme to make it more consistent, easy to understand, and optimized to promote good practices while writing code.
 
-To do that we had to make some changes to our theme in `v3.2.0`. These are breaking changes if you are using some of the tokens in your project. To make it easy for you to upgrade, we are providing three options:
+In order to do this, we had to make some changes to our theme in `v3.2.0`. These are breaking changes if you are using some of the tokens in your project. To make it easy for you to upgrade, we are providing three options:
 
-## Extend previous version's theme for backward compatibility
+##  Extend Previous Version's Theme for Backward Compatibility
 
-You need to add `v3CompatibleTheme` to your `NativeBaseProvider` which preserves all the old token that were changed or removed in v3.2.0.
+You need to add `v3CompatibleTheme` to your `NativeBaseProvider` which preserves all the old tokens that were changed or removed in v3.2.0.
 
 ```jsx
 import {
@@ -34,8 +34,8 @@ If you are updating from 3.1.x to 3.2.x in a Next.js project, you might need to 
 
 ### Updating next.config.js/ts
 
-- Now need to include only react-native-web and native-base in transplie-modules
-- No need of webpack config just add withFonts(from next-fonts) and withExpo(from @expo/next-adapter)
+- Now need to include only react-native-web and native-base in transplie-modules.
+- No need of webpack config just add withFonts(from next-fonts) and withExpo(from @expo/next-adapter).
 
 ```jsx {5-22,27-40}
 const withFonts = require('next-fonts');
@@ -212,9 +212,9 @@ Below is a rough account of the breaking API changes as well as the minimal chan
 
 We have introduced [strict mode](../strict-mode) in `v3.2.0` which is `off` by default. If you don't want to have strict mode, step 1 is enough. If you want to comply with the strict mode, you also need to do these:
 
-1.  All utility props which take theme tokens as values, now take only string values as a valid type
+1.  All utility props which take theme tokens as values, now take only string values as a valid type.
 
-This means that if you pass a number value which is supposed to be a theme token, into a utility prop, then it will be treated as invalid and based on you strict mode config will show you an error or a warning.
+This means that if you pass a number value that is supposed to be a theme token into a utility prop, then it will be treated as invalid and based on your strict mode config will show you an error or a warning.
 
 ```js
 // Incorrect Way to pass theme tokens to utility props


### PR DESCRIPTION
**Old Content -**
As we continue to improve NativeBase v3
easy to understand, optimized and promote good practices while writing code.
To do that we had to make some changes to our theme in `v3.2.0`.
## Extend previous version's theme for backward compatibility
which preserves all the old token that were changed or removed in v3.2.0.
Now need to include only react-native-web and native-base in transplie-modules
No need of webpack config just add withFonts(from next-fonts) and withExpo(from @expo/next-adapter)
 now take only string values as a valid type
This means that if you pass a number value which is supposed to be a theme token, into a utility prop, then it will be treated as invalid and based on you strict mode config will show you an error or a warning.
**New Content -**
As we continued to improve NativeBase v3,
easy to understand, and optimized to promote good practices while writing code.
In order to do this, we had to make some changes to our theme in `v3.2.0`.
## Extend Previous Version's Theme for Backward Compatibility
which preserves all the old tokens that were changed or removed in v3.2.0.
Now need to include only react-native-web and native-base in transplie-modules.
No need of webpack config just add withFonts(from next-fonts) and withExpo(from @expo/next-adapter).
 now take only string values as a valid type.
This means that if you pass a number value that is supposed to be a theme token into a utility prop, then it will be treated as invalid and based on your strict mode config will show you an error or a warning.