### PR TITLE
docs: replace ref link custom fonts on RN project with an recent ref …

### DIFF
--- a/docs/3.4.x/customizing-fonts.md
+++ b/docs/3.4.x/customizing-fonts.md
@@ -9,7 +9,8 @@ Follow 3 simple steps to add a custom font family.
 
 [Refer this guide if you're using Expo](https://docs.expo.io/guides/using-custom-fonts/)
 
-[Refer this guide if you're using React Native init](https://aravindmnair.medium.com/add-custom-fonts-to-react-native-0-60-easily-in-3-steps-fcd71459f4c9)
+[Refer this guide if you're using React Native init](https://blog.logrocket.com/adding-custom-fonts-react-native/)
+
 
 ### Extend NativeBase theme object.
 

--- a/docs/next/customizing-fonts.md
+++ b/docs/next/customizing-fonts.md
@@ -9,8 +9,8 @@ Follow 3 simple steps to add a custom font family.
 
 [Refer this guide if you're using Expo](https://docs.expo.io/guides/using-custom-fonts/)
 
-[Refer this guide if you're using React Native init](https://aravindmnair.medium.com/add-custom-fonts-to-react-native-0-60-easily-in-3-steps-fcd71459f4c9)
-
+[Refer this guide if you're using React Native init](https://blog.logrocket.com/adding-custom-fonts-react-native/)
+  
 ### Extend NativeBase theme object.
 
 We extend the theme object and override `fontConfig` and `fonts` properties which define the mappings.


### PR DESCRIPTION
Hello,

I have submitted a pull request to the Native Base Docs repository for replaces a reference link on the theming customization page in React Native with an updated link to an blog logrocket post from 2022. This change will be useful for those who need to customize fonts using NativeBase with more recent versions of React Native.

I have explained in the pull request description that this change was necessary because I personally encountered this issue and found that ([Refer this guide if you're using React Native init](https://aravindmnair.medium.com/add-custom-fonts-to-react-native-0-60-easily-in-3-steps-fcd71459f4c9)
) ref in documentation did not take into account the fact that, from version 0.69 of React Native, it is no longer possible to use the 'link' command in cli to link assets.

Thank you for your consideration.